### PR TITLE
Not visible when zooming in landscape mode

### DIFF
--- a/app/src/main/java/io/github/domi04151309/alwayson/actions/alwayson/AlwaysOnCustomView.kt
+++ b/app/src/main/java/io/github/domi04151309/alwayson/actions/alwayson/AlwaysOnCustomView.kt
@@ -334,11 +334,8 @@ class AlwaysOnCustomView : View {
             )
 
         return max(
-            max(
-                currentHeight.toInt(),
-                (suggestedMinimumHeight + paddingTop + paddingBottom)
-            ),
-            measuredWidth
+            currentHeight.toInt(),
+            (suggestedMinimumHeight + paddingTop + paddingBottom)
         )
     }
 


### PR DESCRIPTION
When using landscape mode and changing the display size to 200%, then the value of [viewHolder.customView.translationY = screenSize / 4](https://github.com/Domi04151309/AlwaysOn/blob/master/app/src/main/java/io/github/domi04151309/alwayson/actions/alwayson/AlwaysOn.kt#L298) becomes negative, and the widget is not visible on the screen.