### PR TITLE
Brighter colours when coloured icons is on

### DIFF
--- a/app/src/main/java/io/github/domi04151309/alwayson/helpers/ColorHelper.kt
+++ b/app/src/main/java/io/github/domi04151309/alwayson/helpers/ColorHelper.kt
@@ -1,0 +1,24 @@
+package io.github.domi04151309.alwayson.helpers;
+
+import android.graphics.Color
+import kotlin.math.roundToInt
+
+object ColorHelper {
+    fun boostColor(color: Int): Int {
+        val colorRed: Int = Color.red(color)
+        val colorGreen: Int = Color.green(color)
+        val colorBlue: Int = Color.blue(color)
+
+        return if (colorRed < 1 && colorGreen < 1 && colorBlue < 1) {
+            Color.WHITE
+        } else {
+            val rgbMax: Int = maxOf(colorRed, colorGreen, colorBlue)
+            val rgbFactor: Float = 255 / rgbMax.toFloat()
+            val boostedRed: Int = minOf(255, (colorRed * rgbFactor).roundToInt())
+            val boostedGreen: Int = minOf(255, (colorGreen * rgbFactor).roundToInt())
+            val boostedBlue: Int = minOf(255, (colorBlue * rgbFactor).roundToInt())
+            Color.rgb(boostedRed, boostedGreen, boostedBlue)
+        }
+    }
+}
+

--- a/app/src/main/java/io/github/domi04151309/alwayson/helpers/ColorHelper.kt
+++ b/app/src/main/java/io/github/domi04151309/alwayson/helpers/ColorHelper.kt
@@ -1,7 +1,6 @@
-package io.github.domi04151309.alwayson.helpers;
+package io.github.domi04151309.alwayson.helpers
 
 import android.graphics.Color
-import kotlin.math.roundToInt
 
 object ColorHelper {
     fun boostColor(color: Int): Int {
@@ -14,11 +13,10 @@ object ColorHelper {
         } else {
             val rgbMax: Int = maxOf(colorRed, colorGreen, colorBlue)
             val rgbFactor: Float = 255 / rgbMax.toFloat()
-            val boostedRed: Int = minOf(255, (colorRed * rgbFactor).roundToInt())
-            val boostedGreen: Int = minOf(255, (colorGreen * rgbFactor).roundToInt())
-            val boostedBlue: Int = minOf(255, (colorBlue * rgbFactor).roundToInt())
+            val boostedRed: Int = minOf(255, (colorRed * rgbFactor).toInt())
+            val boostedGreen: Int = minOf(255, (colorGreen * rgbFactor).toInt())
+            val boostedBlue: Int = minOf(255, (colorBlue * rgbFactor).toInt())
             Color.rgb(boostedRed, boostedGreen, boostedBlue)
         }
     }
 }
-

--- a/app/src/main/java/io/github/domi04151309/alwayson/services/NotificationService.kt
+++ b/app/src/main/java/io/github/domi04151309/alwayson/services/NotificationService.kt
@@ -10,6 +10,7 @@ import android.service.notification.StatusBarNotification
 import android.util.Log
 import androidx.preference.PreferenceManager
 import io.github.domi04151309.alwayson.actions.alwayson.AlwaysOn
+import io.github.domi04151309.alwayson.helpers.ColorHelper
 import io.github.domi04151309.alwayson.helpers.Global
 import io.github.domi04151309.alwayson.helpers.JSON
 import io.github.domi04151309.alwayson.helpers.Rules
@@ -84,7 +85,7 @@ class NotificationService : NotificationListenerService() {
                     icons.add(
                         Pair(
                             notification.notification.smallIcon,
-                            notification.notification.color,
+                            ColorHelper.boostColor(notification.notification.color),
                         ),
                     )
                 }


### PR DESCRIPTION
Fixes: https://github.com/Domi04151309/AlwaysOn/issues/96

This is another change I have been running that may need to go behind a setting if you wanted to implement it into the app. It makes the "coloured icons" option look much much nicer on the black background.

- Any icons that are 100% black are forced to be 100% white
- Every other icon will be forced to be as bright as possible in their current colour.

Its one of those you'd have to run and see it for yourself but in my opinion the coloured icons option wasn't usable before.

Feel free to contribute to this PR especially as the code is fairly bad (probably) :grin: 